### PR TITLE
Added deleteAll method

### DIFF
--- a/src/http/headers.js
+++ b/src/http/headers.js
@@ -46,6 +46,10 @@ export default class Headers {
     delete(name){
         delete this.map[getName(this.map, name)];
     }
+    
+    deleteAll() {
+        this.map = {};
+    },
 
     forEach(callback, thisArg) {
         each(this.map, (list, name) => {


### PR DESCRIPTION
This is useful for requests to services like slack that throw errors when additional headers are passed.